### PR TITLE
Merging Devel Branch

### DIFF
--- a/apps/image_io/convert_radiograph_dicom_to_proj_data/CMakeLists.txt
+++ b/apps/image_io/convert_radiograph_dicom_to_proj_data/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(EXE_NAME "${XREG_EXE_PREFIX}convert-radiograph-dcm-to-proj-data")
+set(EXE_NAME "${XREG_EXE_PREFIX}convert-dicom-radiograph")
 
 add_executable(${EXE_NAME} xreg_convert_radiograph_dcm_to_proj_data_main.cpp)
 

--- a/apps/image_io/convert_resample_dicom/CMakeLists.txt
+++ b/apps/image_io/convert_resample_dicom/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020 Robert Grupp
+# Copyright (c) 2020-2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-set(EXE_NAME "${XREG_EXE_PREFIX}convert-dicom")
+set(EXE_NAME "${XREG_EXE_PREFIX}convert-dicom-vols")
 
 add_executable(${EXE_NAME} xreg_convert_resample_dicom_main.cpp)
 

--- a/tests/wiki_cmds.py
+++ b/tests/wiki_cmds.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020 Robert Grupp
+# Copyright (c) 2020-2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -185,7 +185,7 @@ if __name__ == '__main__':
        
         extract_zip('ABD_LYMPH_001.zip', 'ABD_LYMPH_001')
 
-        run_cmd('xreg-convert-dicom ABD_LYMPH_001 lymph.nii.gz --one')
+        run_cmd('xreg-convert-dicom-vols ABD_LYMPH_001 lymph.nii.gz --one')
        
         view_vol('lymph.nii.gz', slicer_path)
 


### PR DESCRIPTION
Major change of renaming the DICOM conversion utilities:

- `xreg-convert-dicom` is now `xreg-convert-dicom-vols`
- `convert-radiograph-dcm-to-proj-data` is now `xreg-convert-dicom-radiograph`

Minor change, allowing identity transform as initial guess for `xreg-hip-surg-pelvis-single-view-regi-2d-3d`.