### PR TITLE
Latest development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ cmake_minimum_required(VERSION 3.13.0 FATAL_ERROR)
 #endif ()
 
 # Version format is YYYY.MM.DD for a release and YYYY.MM.DD.1 for devel after the release
-project(xreg VERSION 2021.09.19.0)
+project(xreg VERSION 2021.09.19.1)
 
 set (CMAKE_CXX_STANDARD "11" CACHE STRING "C++ Standard (needs at least 11)")
 mark_as_advanced(CMAKE_CXX_STANDARD)

--- a/apps/image_io/convert_spare_projs_to_proj_data/CMakeLists.txt
+++ b/apps/image_io/convert_spare_projs_to_proj_data/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 Robert Grupp
+# Copyright (c) 2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_subdirectory(convert_resample_dicom)
-add_subdirectory(report_dicom)
-add_subdirectory(crop_vol)
-add_subdirectory(remap_and_tile_proj_data)
-add_subdirectory(extract_nii_from_proj_data)
-add_subdirectory(add_lands_to_proj_data)
-add_subdirectory(draw_xray_scene)
-add_subdirectory(regi2d3d_replay)
-add_subdirectory(convert_rad_raw_to_proj_data)
-add_subdirectory(convert_sta_raw_to_itk)
-add_subdirectory(convert_radiograph_dicom_to_proj_data)
-add_subdirectory(make_video_from_image_dir)
-add_subdirectory(remap_dicom_dir)
-add_subdirectory(proj_cat)
-add_subdirectory(proj_make_fiducial_world)
-add_subdirectory(proj_est_orbital_rot)
-add_subdirectory(convert_spare_projs_to_proj_data)
+set(EXE_NAME "${XREG_EXE_PREFIX}convert-spare-proj-data")
+
+add_executable(${EXE_NAME} xreg_convert_spare_projs_to_proj_data_main.cpp)
+
+target_link_libraries(${EXE_NAME} PUBLIC ${XREG_EXE_LIBS_TO_LINK})
+
+install(TARGETS ${EXE_NAME})
 

--- a/apps/image_io/convert_spare_projs_to_proj_data/xreg_convert_spare_projs_to_proj_data_main.cpp
+++ b/apps/image_io/convert_spare_projs_to_proj_data/xreg_convert_spare_projs_to_proj_data_main.cpp
@@ -1,0 +1,251 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fmt/format.h>
+
+#include "xregFilesystemUtils.h"
+#include "xregH5ProjDataIO.h"
+#include "xregITKBasicImageUtils.h"
+#include "xregProgOptUtils.h"
+#include "xregRTKGeom.h"
+
+using namespace xreg;
+
+int main(int argc, char* argv[])
+{
+  constexpr int kEXIT_VAL_SUCCESS   = 0;
+  constexpr int kEXIT_VAL_BAD_USE   = 1;
+  constexpr int kEXIT_VAL_BAD_DATA  = 2;
+
+  ProgOpts po;
+
+  xregPROG_OPTS_SET_COMPILE_DATE(po);
+
+  po.set_help("Converts a collection of 2D projection images the SPARE dataset/challenge "
+              "into an HDF5 projection data file for use by xReg. "
+              "SPARE homepage: https://image-x.sydney.edu.au/spare-challenge .");
+  po.set_arg_usage("<Input SPARE projs directory> <Output xReg HDF5 file>");
+  po.set_min_num_pos_args(2);
+
+  try
+  {
+    po.parse(argc, argv);
+  }
+  catch (const ProgOpts::Exception& e)
+  {
+    std::cerr << "Error parsing command line arguments: " << e.what() << std::endl;
+    po.print_usage(std::cerr);
+    return kEXIT_VAL_BAD_USE;
+  }
+
+  if (po.help_set())
+  {
+    po.print_usage(std::cout);
+    po.print_help(std::cout);
+    return kEXIT_VAL_SUCCESS;
+  }
+
+  std::ostream& vout = po.vout();
+
+  const std::string& src_spare_dir = po.pos_args()[0];
+  const std::string& dst_pd_path   = po.pos_args()[1];
+
+  const Path src_dir_path(src_spare_dir);
+
+  const Path geom_xml_path = src_dir_path + "Geometry.xml";
+
+  if (!geom_xml_path.exists())
+  {
+    std::cerr << "ERROR: Geometry.xml file not located in SPARE directory!" << std::endl;
+    return kEXIT_VAL_BAD_DATA;
+  }
+
+  vout << "reading RTK geometry XML..." << std::endl;
+  const auto rtk_geom_info = ReadRTKGeomInfoFromXMLFile(geom_xml_path.string());
+
+  const size_type num_projs = rtk_geom_info.proj_infos.size();
+  
+  vout << "num. projs.: " << num_projs << std::endl;
+
+  size_type proj_file_size = 0;
+
+  {
+    const Path first_proj_path = src_dir_path + "Proj_00001.bin";
+
+    vout << "checking file size of first proj: " << first_proj_path.string() << std::endl;
+
+    if (!first_proj_path.exists())
+    {
+      std::cerr << "ERROR: first projection file does not existing: "
+                << first_proj_path.string() << std::endl;
+      return kEXIT_VAL_BAD_DATA;
+    }
+
+    proj_file_size = FileInputStream(first_proj_path.string()).num_bytes_left();
+  }
+
+  vout << "proj. file size: " << proj_file_size << std::endl;
+
+  size_type proj_num_rows = 0;
+  size_type proj_num_cols = 0;
+  CoordScalar ps = 0;
+  CoordScalar expected_src_to_det = 0;
+  CoordScalar expected_src_to_iso = 0;
+
+  switch (proj_file_size)
+  {
+  case size_type(512 * 512 * 4):
+    vout << "detected Elekta dataset" << std::endl;
+    proj_num_rows = 512;
+    proj_num_cols = 512;
+    ps = 0.8f;
+    expected_src_to_det = 1536;
+    expected_src_to_iso = 1000;
+    break;
+  case size_type(1024 * 768 * 4):
+    vout << "detected Varian P1/P2 dataset" << std::endl;
+    proj_num_rows = 1024;
+    proj_num_cols = 768;
+    ps = 0.388f;
+    expected_src_to_det = 1500;
+    expected_src_to_iso = 1000;
+    break;
+  case size_type(1008 * 752 * 4):
+    vout << "detected Varian P3/P4/P5 dataset" << std::endl;
+    proj_num_rows = 1008;
+    proj_num_cols = 752;
+    ps = 0.388f;
+    expected_src_to_det = 1500;
+    expected_src_to_iso = 1000;
+    break;
+  case size_type(512 * 384 * 4):
+    vout << "detected Monte Carlo simulated dataset" << std::endl;
+    proj_num_rows = 512;
+    proj_num_cols = 384;
+    ps = 0.776f;
+    expected_src_to_det = 1500;
+    expected_src_to_iso = 1000;
+    break;
+  default:
+    std::cerr << "Unable to determine data source from file size: "
+              << proj_file_size << std::endl;
+    return kEXIT_VAL_BAD_DATA;
+  }
+
+  if (std::abs(rtk_geom_info.src_to_iso_center_dist_mm - expected_src_to_iso) > 1.0e-6f)
+  {
+    std::cerr << fmt::format("ERROR: source-to-isocenter from XML ({:.3f}) does not match expected ({:.3f})") << std::endl;
+    return kEXIT_VAL_BAD_DATA;
+  }
+
+  if (std::abs(rtk_geom_info.src_to_det_dist_mm - expected_src_to_det) > 1.0e-6f)
+  {
+    std::cerr << fmt::format("ERROR: source-to-detector from XML ({:.3f}) does not match expected ({:.3f})") << std::endl;
+    return kEXIT_VAL_BAD_DATA;
+  }
+  
+  ProjDataF32List pd(num_projs);
+
+  // The RTK geometry projects to physical points (e.g. in mm with origin at the center of the image),
+  // this converts those into pixel indices (e.g. in pixels with origin at the corner pixel (0,0). 
+  Mat3x3 intrins_phys_to_pixels = Mat3x3::Identity();
+  intrins_phys_to_pixels(0,0) = CoordScalar(1) / ps;
+  intrins_phys_to_pixels(1,1) = CoordScalar(1) / ps;
+  intrins_phys_to_pixels(0,2) = proj_num_cols / CoordScalar(2);
+  intrins_phys_to_pixels(1,2) = proj_num_rows / CoordScalar(2);
+  
+  Mat3x3 K;
+  Mat4x4 H;
+  CoordScalar rho;
+ 
+  vout << "creating camera models for each proj..." << std::endl; 
+  for (size_type i = 0; i < num_projs; ++i)
+  {
+    vout << fmt::format("  proj.: {:4d}", i) << std::endl;
+
+    std::tie(K,H,rho) = DecompProjMat(rtk_geom_info.proj_infos[i].cam_mat, true);
+    
+    auto& cam = pd[i].cam;
+
+    pd[i].cam.setup(intrins_phys_to_pixels * K, H, proj_num_rows, proj_num_cols, ps, ps);
+    xregASSERT(std::abs(pd[i].cam.focal_len - rtk_geom_info.src_to_det_dist_mm) < 1.0e-3f);
+  }
+  vout << "---------------------------------\n\n";
+
+  const size_type tot_num_pix = proj_num_cols * proj_num_rows;
+
+  // The projection pixels are stored on disk in column-major, but we eventually need them in
+  // row-major order. We will use a column-major representation when reading from disk and
+  // then copy it into a row-major overlay on the ITK image buffer.
+  using MatColMaj = Eigen::Matrix<float,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor|Eigen::DontAlign>;
+  using MatRowMaj = Eigen::Matrix<float,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor|Eigen::DontAlign>;
+
+  MatColMaj tmp_proj_buf(proj_num_rows, proj_num_cols);
+
+  std::array<double,2> tmp_spacing = { static_cast<double>(ps), static_cast<double>(ps) };
+
+  vout << "reading projection pixels files..." << std::endl;
+
+  for (size_type i = 0; i < num_projs; ++i)
+  {
+    vout << fmt::format("  proj.: {:4d}", i) << std::endl;
+
+    const Path cur_proj_path = src_dir_path + fmt::format("Proj_{:05d}.bin", i+1);
+    
+    if (!cur_proj_path.exists())
+    {
+      std::cerr << "ERROR: projection file does not exist: " << cur_proj_path.string()
+                << std::endl;
+      return kEXIT_VAL_BAD_DATA;
+    }
+
+    FileInputStream fin(cur_proj_path.string());
+
+    if (fin.num_bytes_left() != proj_file_size)
+    {
+      std::cerr << "ERROR: proj. file size (" << fin.num_bytes_left()
+                << ") does not match expected (" << proj_file_size  << "): "
+                << cur_proj_path.string() << std::endl;
+      return kEXIT_VAL_BAD_DATA;
+    }
+    
+    auto img = MakeITK2DVol<float>(proj_num_cols, proj_num_rows);
+    
+    img->SetSpacing(tmp_spacing.data());
+
+    fin.read(&tmp_proj_buf(0,0), tot_num_pix);
+    
+    Eigen::Map<MatRowMaj> dst_proj_buf(img->GetBufferPointer(), proj_num_rows, proj_num_cols);
+    dst_proj_buf = tmp_proj_buf;
+
+    pd[i].img = img;
+  }
+
+  vout << "saving to proj data HDF5..." << std::endl;
+  WriteProjDataH5ToDisk(pd, dst_pd_path);
+
+  vout << "exiting..." << std::endl;
+  return kEXIT_VAL_SUCCESS;
+}
+

--- a/apps/image_io/extract_nii_from_proj_data/xreg_extract_nii_from_proj_data_main.cpp
+++ b/apps/image_io/extract_nii_from_proj_data/xreg_extract_nii_from_proj_data_main.cpp
@@ -151,6 +151,8 @@ int main(int argc, char* argv[])
   }
 
   std::ostream& vout = po.vout();
+  
+  const std::string proj_inds_str = po.get("projs");
 
   const bool ignore_pat_rot_up = po.get("no-pat-rot-up");
 
@@ -180,7 +182,6 @@ int main(int argc, char* argv[])
 
   const std::string proj_data_path = po.pos_args()[0];
   const std::string nii_prefix     = po.pos_args()[1];
-  const std::string proj_inds_str  = (po.pos_args().size()) > 2 ? po.pos_args()[2] : std::string();
 
   vout << "creating proj data reader obj..." << std::endl;
   DeferredProjReader pd_reader(proj_data_path);

--- a/apps/image_io/proj_cat/CMakeLists.txt
+++ b/apps/image_io/proj_cat/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 Robert Grupp
+# Copyright (c) 2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,18 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_subdirectory(convert_resample_dicom)
-add_subdirectory(report_dicom)
-add_subdirectory(crop_vol)
-add_subdirectory(remap_and_tile_proj_data)
-add_subdirectory(extract_nii_from_proj_data)
-add_subdirectory(add_lands_to_proj_data)
-add_subdirectory(draw_xray_scene)
-add_subdirectory(regi2d3d_replay)
-add_subdirectory(convert_rad_raw_to_proj_data)
-add_subdirectory(convert_sta_raw_to_itk)
-add_subdirectory(convert_radiograph_dicom_to_proj_data)
-add_subdirectory(make_video_from_image_dir)
-add_subdirectory(remap_dicom_dir)
-add_subdirectory(proj_cat)
+set(EXE_NAME "${XREG_EXE_PREFIX}proj-cat")
+
+add_executable(${EXE_NAME} xreg_proj_cat_main.cpp)
+
+target_link_libraries(${EXE_NAME} PUBLIC ${XREG_EXE_LIBS_TO_LINK})
+
+install(TARGETS ${EXE_NAME})
 

--- a/apps/image_io/proj_cat/xreg_proj_cat_main.cpp
+++ b/apps/image_io/proj_cat/xreg_proj_cat_main.cpp
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregProgOptUtils.h"
+#include "xregHDF5.h"
+#include "xregH5ProjDataIO.h"
+
+int main(int argc, char* argv[])
+{
+  constexpr int kEXIT_VAL_SUCCESS  = 0;
+  constexpr int kEXIT_VAL_BAD_USE  = 1;
+
+  using namespace xreg;
+
+  ProgOpts po;
+
+  xregPROG_OPTS_SET_COMPILE_DATE(po);
+
+  po.set_help("Concatenates more than one proj. data HDF5 files into a single output "
+      "HDF5 file. The projections of the first file are the first projections inserted "
+      "into the output file, followed by those of the second, and so forth. This utility "
+      "is helpful when setting up a multiple-view geometry from a collection of "
+      "single-views.");
+  po.set_arg_usage("<Input Proj. Data File #1> <Input Proj. Data File #2> "
+      "[... <Input Proj. Data File #N>] <Output Concatenated Proj. Data File>");
+  po.set_min_num_pos_args(3);
+
+  try
+  {
+    po.parse(argc, argv);
+  }
+  catch (const ProgOpts::Exception& e)
+  {
+    std::cerr << "Error parsing command line arguments: " << e.what() << std::endl;
+    po.print_usage(std::cerr);
+    return kEXIT_VAL_BAD_USE;
+  }
+
+  if (po.help_set())
+  {
+    po.print_usage(std::cout);
+    po.print_help(std::cout);
+    return kEXIT_VAL_SUCCESS;
+  }
+
+  std::ostream& vout = po.vout();
+
+  const auto pos_args = po.pos_args();
+
+  const size_type num_input_proj_files = pos_args.size() - 1;
+
+  const std::string dst_cat_proj_path = pos_args.back();
+
+  vout << "opening H5 file for writing: " << dst_cat_proj_path << std::endl;
+  H5::H5File dst_h5(dst_cat_proj_path, H5F_ACC_TRUNC);
+  
+  SetStringAttr("xreg-type", kXREG_PROJ_DATA_ATTR_STR, &dst_h5);
+
+  const auto dst_h5_id = dst_h5.getId();
+
+  size_type num_dst_projs = 0;
+
+  for (size_type src_file_idx = 0; src_file_idx < num_input_proj_files; ++src_file_idx)
+  {
+    const auto& cur_src_h5_path = pos_args[src_file_idx];
+
+    vout << "  opening up proj. H5 file " << src_file_idx << " for reading: "
+         << cur_src_h5_path << std::endl;
+
+    H5::H5File cur_src_h5(cur_src_h5_path, H5F_ACC_RDONLY);
+
+    const auto cur_src_h5_id = cur_src_h5.getId();
+
+    const size_type cur_file_num_projs = ReadSingleScalarH5ULong("num-projs", cur_src_h5);
+
+    vout << "    num-projs: " << cur_file_num_projs << std::endl;
+
+    for (size_type cur_file_proj_idx = 0; cur_file_proj_idx < cur_file_num_projs;
+        ++cur_file_proj_idx, ++num_dst_projs)
+    {
+      vout << "      copying proj: " << cur_file_proj_idx << std::endl;
+
+      const std::string src_group_name = fmt::format("proj-{:03d}", cur_file_proj_idx);
+
+      const std::string dst_group_name = fmt::format("proj-{:03d}", num_dst_projs);
+
+      H5Ocopy(cur_src_h5_id, src_group_name.c_str(),
+              dst_h5_id, dst_group_name.c_str(),
+              H5P_DEFAULT, H5P_DEFAULT);
+    }
+  }
+
+  WriteSingleScalarH5("num-projs", num_dst_projs, &dst_h5);
+  
+  dst_h5.flush(H5F_SCOPE_GLOBAL);
+  dst_h5.close();
+
+  vout << "exiting..." << std::endl;
+  return kEXIT_VAL_SUCCESS;
+}

--- a/apps/image_io/proj_est_orbital_rot/CMakeLists.txt
+++ b/apps/image_io/proj_est_orbital_rot/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 Robert Grupp
+# Copyright (c) 2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,20 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_subdirectory(convert_resample_dicom)
-add_subdirectory(report_dicom)
-add_subdirectory(crop_vol)
-add_subdirectory(remap_and_tile_proj_data)
-add_subdirectory(extract_nii_from_proj_data)
-add_subdirectory(add_lands_to_proj_data)
-add_subdirectory(draw_xray_scene)
-add_subdirectory(regi2d3d_replay)
-add_subdirectory(convert_rad_raw_to_proj_data)
-add_subdirectory(convert_sta_raw_to_itk)
-add_subdirectory(convert_radiograph_dicom_to_proj_data)
-add_subdirectory(make_video_from_image_dir)
-add_subdirectory(remap_dicom_dir)
-add_subdirectory(proj_cat)
-add_subdirectory(proj_make_fiducial_world)
-add_subdirectory(proj_est_orbital_rot)
+set(EXE_NAME "${XREG_EXE_PREFIX}proj-est-orbital-rot")
+
+add_executable(${EXE_NAME} xreg_proj_est_orbital_rot_main.cpp)
+
+target_link_libraries(${EXE_NAME} PUBLIC ${XREG_EXE_LIBS_TO_LINK})
+
+install(TARGETS ${EXE_NAME})
 

--- a/apps/image_io/proj_est_orbital_rot/xreg_proj_est_orbital_rot_main.cpp
+++ b/apps/image_io/proj_est_orbital_rot/xreg_proj_est_orbital_rot_main.cpp
@@ -1,0 +1,268 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregProgOptUtils.h"
+#include "xregHDF5.h"
+#include "xregH5ProjDataIO.h"
+#include "xregH5CamModelIO.h"
+#include "xregPerspectiveXform.h"
+#include "xregRotUtils.h"
+#include "xregFitCylinder.h"
+#include "xregVTK3DPlotter.h"
+
+int main(int argc, char* argv[])
+{
+  constexpr int kEXIT_VAL_SUCCESS  = 0;
+  constexpr int kEXIT_VAL_BAD_USE  = 1;
+
+  using namespace xreg;
+
+  ProgOpts po;
+
+  xregPROG_OPTS_SET_COMPILE_DATE(po);
+
+  // The method used here is derived from the following paper:
+  // Navab N, Bani-Hashemi A, Nadar MS, Wiesent K, Durlak P, Brunner T, Barth K, Graumann R.
+  // 3D reconstruction from projection matrices in a C-arm based 3D-angiography system.
+  // In International Conference on Medical Image Computing and Computer-Assisted
+  // Intervention 1998 Oct 11 (pp. 119-129). Springer, Berlin, Heidelberg.
+
+  po.set_help("Given a collection of projections collected as part of an orbital "
+      "rotation, estimate the axis of rotation and the center of rotation. "
+      "The updated extrinsic matrix for a reference view are printed to standard out. "
+      "This optionally updates the extrinsic frames of the input projection file. "
+      "Uses the method described by the 1998 MICCAI by Navab, et al..");
+  
+  po.set_arg_usage("<Proj. Data File>");
+  
+  po.set_min_num_pos_args(1);
+
+  po.add("ref-proj", 'p', ProgOpts::kSTORE_UINT64, "ref-proj",
+         "The index of the reference projection used to estimate the new y-axis and "
+         "print out the new extrinsic frame. When not supplied, either the "
+         "first (when not reversing projection order) or last projection (when reversing "
+         "projection order) is used.");
+
+  po.add("update", 'u', ProgOpts::kSTORE_TRUE, "update",
+         "Update the input projection data file to use the new extrinsic frame.")
+    << false;
+
+  po.add("reverse", 'r', ProgOpts::kSTORE_TRUE, "reverse",
+         "reverse the order of projections when calculating the orbit rotation axis.")
+    << false;;
+
+  po.add("debug", 'd', ProgOpts::kSTORE_TRUE, "debug",
+         "Display a debug visualization of the newly computed coordinate frame.")
+    << false;
+
+  try
+  {
+    po.parse(argc, argv);
+  }
+  catch (const ProgOpts::Exception& e)
+  {
+    std::cerr << "Error parsing command line arguments: " << e.what() << std::endl;
+    po.print_usage(std::cerr);
+    return kEXIT_VAL_BAD_USE;
+  }
+
+  if (po.help_set())
+  {
+    po.print_usage(std::cout);
+    po.print_help(std::cout);
+    return kEXIT_VAL_SUCCESS;
+  }
+
+  std::ostream& vout = po.vout();
+
+  const bool has_ref_proj_idx = po.has("ref-proj");
+
+  const bool update_proj_data = po.get("update");
+
+  const bool reverse_order = po.get("reverse");
+
+  const bool debug_disp = po.get("debug");
+
+  const std::string proj_path = po.pos_args()[0];
+
+  vout << "opening H5 file for "
+       << (update_proj_data ? "modification" : "reading") << ": "
+       << proj_path << std::endl;
+  H5::H5File h5(proj_path, update_proj_data ? H5F_ACC_RDWR : H5F_ACC_RDONLY);
+    
+  const size_type num_projs = ReadSingleScalarH5ULong("num-projs", h5);
+
+  if (num_projs < 3)
+  {
+    std::cerr << "need at least three projections, this file has: " << num_projs << std::endl;
+    return kEXIT_VAL_BAD_USE;
+  }
+ 
+  vout << "num. projs. in file: " << num_projs << std::endl;
+
+  const size_type ref_proj_idx = has_ref_proj_idx ?
+    static_cast<size_type>(po.get("ref-proj").as_uint64()) :
+    (reverse_order ? (num_projs - 1) : size_type(0));
+  
+  vout << "ref. proj. index: " << ref_proj_idx << std::endl;
+  xregASSERT(ref_proj_idx < num_projs);
+
+  vout << "extracting existing camera models..." << std::endl;
+  auto cams = ReadCamModelsFromProjData(h5);
+  xregASSERT(cams.size() == num_projs);
+
+  vout << "estimating orbital rotation axis..." << std::endl;
+  
+  const size_type num_projs_minus_1 = num_projs - 1;
+
+  Mat3x3List delta_rots;
+  delta_rots.reserve(num_projs_minus_1);
+  
+  vout << "  calc. rotation deltas between adjacent projections..." << std::endl;
+  vout << "    reverse order? " << (reverse_order ? "YES" : "NO") << std::endl;
+
+  for (size_type i = 0; i < num_projs_minus_1; ++i)
+  {
+    const size_type idx_1 = reverse_order ? (num_projs_minus_1 - i) : i;
+    const size_type idx_2 = reverse_order ? (num_projs_minus_1 - 1 - i) : (i + 1);
+    
+    const Mat3x3 delta_R = (cams[idx_2].extrins_inv * cams[idx_1].extrins).matrix().block(0,0,3,3);
+
+    delta_rots.push_back(delta_R);
+    
+    vout << fmt::format("    {:2d} --> {:2d} : {:4.1f} (deg.)", idx_1, idx_2, LogSO3ToPt(delta_R).norm() * kRAD2DEG) << std::endl;
+  }
+
+  const Mat3x3 mean_delta_R = SO3FrechetMean(delta_rots);
+
+  // This will be the x-axis in the updated extrinsic frame
+  Pt3 mean_rot_axis = LogSO3ToPt(mean_delta_R);
+  mean_rot_axis.normalize();
+
+  // The y-axis will be approximately source-to-detector direction of reference view
+  const auto& ref_cam = cams[ref_proj_idx];
+
+  Pt3 ref_cam_src_to_det = ref_cam.ind_pt_to_phys_det_pt(
+                              Pt2(ref_cam.intrins.block(0,2,2,1)))
+                           - ref_cam.pinhole_pt;
+  ref_cam_src_to_det.normalize();
+
+  Pt3 y_axis = ref_cam_src_to_det -
+                  (ref_cam_src_to_det.dot(mean_rot_axis) * mean_rot_axis);
+  y_axis.normalize();
+
+  Mat3x3 new_to_old_R;
+  new_to_old_R.col(0) = mean_rot_axis;
+  new_to_old_R.col(1) = y_axis;
+  new_to_old_R.col(2) = mean_rot_axis.cross(y_axis);
+
+  vout << "new to old, R^T * R:\n" << new_to_old_R.transpose() * new_to_old_R << std::endl;
+  
+  vout << "det(new to old R): " << new_to_old_R.determinant() << std::endl;
+
+  xregASSERT(std::abs(new_to_old_R.col(0).dot(new_to_old_R.col(1))) < 1.0e-6f);
+  xregASSERT(std::abs(new_to_old_R.col(0).dot(new_to_old_R.col(2))) < 1.0e-6f);
+  xregASSERT(std::abs(new_to_old_R.col(1).dot(new_to_old_R.col(2))) < 1.0e-6f);
+
+  vout << "estimating center of rotation from x-ray source positions..." << std::endl;
+
+  Pt3List src_pts;
+  src_pts.reserve(num_projs);
+
+  for (size_type i = 0; i < num_projs; ++i)
+  {
+    src_pts.push_back(cams[i].pinhole_pt);
+  }
+
+  Pt3 center_of_rot;
+  CoordScalar orbit_radius = 0;
+  std::tie(center_of_rot, orbit_radius) = FitOrbitToPts(src_pts);
+
+  if (debug_disp)
+  {
+    vout << "creating debug visualization..." << std::endl;
+
+    VTK3DPlotter plotter;
+
+    plotter.add_pts(src_pts, 0, 1, 0);
+    
+    plotter.add_sphere(center_of_rot, 5, 1, 1, 0);
+    
+    plotter.add_circle(center_of_rot, orbit_radius, mean_rot_axis, 0, 0, 0);
+
+    constexpr CoordScalar AXIS_LEN = 20;
+
+    plotter.add_arrow(center_of_rot,
+                      center_of_rot + (new_to_old_R * Pt3(AXIS_LEN,0,0)),
+                      1, 0, 0);
+
+    plotter.add_arrow(center_of_rot,
+                      center_of_rot + (new_to_old_R * Pt3(0,AXIS_LEN,0)),
+                      0, 1, 0);
+    
+    plotter.add_arrow(center_of_rot,
+                      center_of_rot + (new_to_old_R * Pt3(0,0,AXIS_LEN)),
+                      0, 0, 1);
+
+    plotter.show();
+  }
+
+  FrameTransform new_extrins_to_old = FrameTransform::Identity();
+  new_extrins_to_old.matrix().block(0,0,3,3) = new_to_old_R;
+  new_extrins_to_old.matrix().block(0,3,3,1) = center_of_rot;
+
+  Eigen::IOFormat HeavyFmt(Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+  std::cout << "Updated extrinsic matrix:\n"
+            << (ref_cam.extrins * new_extrins_to_old).matrix().format(HeavyFmt)
+            << std::endl;
+
+  if (update_proj_data)
+  {
+    vout << "updating camera models in HDF5..." << std::endl;
+    for (size_type i = 0; i < num_projs; ++i)
+    {
+      vout << "  proj " << i << std::endl;
+
+      H5::Group proj_g = h5.openGroup(fmt::format("proj-{:03d}", i));
+
+      proj_g.unlink("cam");
+
+      H5::Group cam_g = proj_g.createGroup("cam");
+
+      auto& cam = cams[i];
+
+      cam.extrins = cam.extrins * new_extrins_to_old;
+      cam.extrins_inv = cam.extrins.inverse(Eigen::Isometry);
+
+      WriteCamModelH5(cam, &cam_g);
+    }
+
+    h5.flush(H5F_SCOPE_GLOBAL);
+  }
+
+  h5.close();
+
+  vout << "exiting..." << std::endl;
+  return kEXIT_VAL_SUCCESS;
+}

--- a/apps/image_io/proj_make_fiducial_world/CMakeLists.txt
+++ b/apps/image_io/proj_make_fiducial_world/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020-2021 Robert Grupp
+# Copyright (c) 2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,19 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-add_subdirectory(convert_resample_dicom)
-add_subdirectory(report_dicom)
-add_subdirectory(crop_vol)
-add_subdirectory(remap_and_tile_proj_data)
-add_subdirectory(extract_nii_from_proj_data)
-add_subdirectory(add_lands_to_proj_data)
-add_subdirectory(draw_xray_scene)
-add_subdirectory(regi2d3d_replay)
-add_subdirectory(convert_rad_raw_to_proj_data)
-add_subdirectory(convert_sta_raw_to_itk)
-add_subdirectory(convert_radiograph_dicom_to_proj_data)
-add_subdirectory(make_video_from_image_dir)
-add_subdirectory(remap_dicom_dir)
-add_subdirectory(proj_cat)
-add_subdirectory(proj_make_fiducial_world)
+set(EXE_NAME "${XREG_EXE_PREFIX}proj-make-fiducial-world")
+
+add_executable(${EXE_NAME} xreg_proj_make_fiducial_world_main.cpp)
+
+target_link_libraries(${EXE_NAME} PUBLIC ${XREG_EXE_LIBS_TO_LINK})
+
+install(TARGETS ${EXE_NAME})
 

--- a/apps/image_io/proj_make_fiducial_world/xreg_proj_make_fiducial_world_main.cpp
+++ b/apps/image_io/proj_make_fiducial_world/xreg_proj_make_fiducial_world_main.cpp
@@ -1,0 +1,140 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregProgOptUtils.h"
+#include "xregHDF5.h"
+#include "xregH5ProjDataIO.h"
+#include "xregH5CamModelIO.h"
+#include "xregITKIOUtils.h"
+#include "xregPerspectiveXform.h"
+
+int main(int argc, char* argv[])
+{
+  constexpr int kEXIT_VAL_SUCCESS  = 0;
+  constexpr int kEXIT_VAL_BAD_USE  = 1;
+
+  using namespace xreg;
+
+  ProgOpts po;
+
+  xregPROG_OPTS_SET_COMPILE_DATE(po);
+
+  po.set_help("Updates the extrinsic transformations of each projection using previously "
+      "computed transformations (e.g. via registration) from the existing projection "
+      "extrinsic frames to a fiducial coordinate frame. The input projection file is "
+      "modified. A transformation must be specified for each projection or pass a \"-\" "
+      "value to indicate the extrinsic transformation should not be updated.");
+  
+  po.set_arg_usage("<Proj. Data File> <Proj. #1 cam wrt. fid.> "
+      "[... <Proj. #N cam wrt. fid.>]");
+  
+  po.set_min_num_pos_args(2);
+
+  try
+  {
+    po.parse(argc, argv);
+  }
+  catch (const ProgOpts::Exception& e)
+  {
+    std::cerr << "Error parsing command line arguments: " << e.what() << std::endl;
+    po.print_usage(std::cerr);
+    return kEXIT_VAL_BAD_USE;
+  }
+
+  if (po.help_set())
+  {
+    po.print_usage(std::cout);
+    po.print_help(std::cout);
+    return kEXIT_VAL_SUCCESS;
+  }
+
+  std::ostream& vout = po.vout();
+
+  const auto pos_args = po.pos_args();
+
+  const size_type num_xform_files = pos_args.size() - 1;
+
+  const std::string proj_path = pos_args[0];
+
+  vout << "opening H5 file for modification: " << proj_path << std::endl;
+  H5::H5File h5(proj_path, H5F_ACC_RDWR);
+    
+  const size_type num_projs = ReadSingleScalarH5ULong("num-projs", h5);
+ 
+  vout << "num. projs. in file: " << num_projs << std::endl;
+
+  if (num_xform_files != num_projs)
+  {
+    std::cerr << "ERROR: number of passed transforms (" << num_xform_files
+      << ") must match number of projections in file (" << num_projs << ")!" << std::endl;
+    return kEXIT_VAL_BAD_USE;
+  }
+
+  std::vector<FrameTransform> xforms;
+  xforms.reserve(num_projs);
+
+  for (size_type i = 0; i < num_projs; ++i)
+  {
+    const auto& cur_xform_path = pos_args[1 + i];
+   
+    if (cur_xform_path != "-")
+    {
+      vout << "  reading transform for projection " << i << ": "
+           << cur_xform_path << std::endl;
+
+      xforms.push_back(ReadITKAffineTransformFromFile(cur_xform_path));
+    }
+    else
+    {
+      vout << "  using identity for projection " << i << std::endl;
+      xforms.push_back(FrameTransform::Identity());
+    }
+  }
+
+  vout << "extracting existing camera models..." << std::endl;
+  auto cams = ReadCamModelsFromProjData(h5);
+
+  vout << "calculating new fiducial world coords..." << std::endl;
+  cams = CreateCameraWorldUsingFiducial(cams, xforms);
+  
+  vout << "updating camera models in HDF5..." << std::endl;
+  for (size_type i = 0; i < num_projs; ++i)
+  {
+    vout << "  proj " << i << std::endl;
+
+    H5::Group proj_g = h5.openGroup(fmt::format("proj-{:03d}", i));
+
+    proj_g.unlink("cam");
+
+    H5::Group cam_g = proj_g.createGroup("cam");
+
+    WriteCamModelH5(cams[i], &cam_g);
+  }
+
+  h5.flush(H5F_SCOPE_GLOBAL);
+  h5.close();
+
+  vout << "exiting..." << std::endl;
+  return kEXIT_VAL_SUCCESS;
+}

--- a/example_build_script
+++ b/example_build_script
@@ -28,6 +28,18 @@ DEPS_DIR="$(cd "$(dirname "$DEPS_DIR")"; pwd)/$(basename "$DEPS_DIR")"
 mkdir -p $DEPS_DIR
 cd $DEPS_DIR
 
+if ! [ -x "$(command -v wget)" ]; then
+  echo "wget is not available, using a wrapper to curl instead."
+
+  function wget()
+  {
+    FILENAME_TO_DOWNLOAD=`basename $1`
+    echo "Downloading $FILENAME_TO_DOWNLOAD ..."
+
+    curl -L -O $1
+  }
+fi
+
 if [ "$NEED_TO_DOWNLOAD" = true ]; then
   echo "Downloading third party libraries..."
   

--- a/example_build_script_2
+++ b/example_build_script_2
@@ -65,6 +65,18 @@ mkdir -p $DEPS_INSTALL_DIR
 
 cd $DEPS_DIR
 
+if ! [ -x "$(command -v wget)" ]; then
+  echo "wget is not available, using a wrapper to curl instead."
+
+  function wget()
+  {
+    FILENAME_TO_DOWNLOAD=`basename $1`
+    echo "Downloading $FILENAME_TO_DOWNLOAD ..."
+
+    curl -L -O $1
+  }
+fi
+
 # Operating system name
 OS_STR=`uname -s`
 

--- a/lib/file_formats/CMakeLists.txt
+++ b/lib/file_formats/CMakeLists.txt
@@ -39,7 +39,8 @@ set(xreg_file_formats_src ${XREG_CUR_LIB_HEADERS}
                           xregWriteVideo.cpp
                           xregRadRawProj.cpp
                           xregStaRawVol.cpp
-                          xregReadProjDataFromDICOM.cpp)
+                          xregReadProjDataFromDICOM.cpp
+                          xregRTKGeom.cpp)
 
 if (APPLE)
   set(xreg_file_formats_src ${xreg_file_formats_src}

--- a/lib/file_formats/xregDICOMUtils.cpp
+++ b/lib/file_formats/xregDICOMUtils.cpp
@@ -577,7 +577,19 @@ xreg::DICOMFIleBasicFields xreg::ReadDICOMFileBasicFields(const std::string& dcm
         {
           xregASSERT(dist_src_to_det_attr.GetNumberOfValues() == 1);
           
-          dcm_info.dist_src_to_det_mm = dist_src_to_det_attr.GetValue();
+          const auto src_to_det_mm = dist_src_to_det_attr.GetValue();
+
+          // Some datasets have this value, but it is set to zero and is not useful.
+          // Only populate this field when the value is non-zero.
+          if (src_to_det_mm > 1.0e-8)
+          {
+            dcm_info.dist_src_to_det_mm = src_to_det_mm;
+          }
+          else
+          {
+            std::cerr << "WARNING: source-to-detector distance field present, "
+              "but not a positive value. Discarding." << std::endl;
+          }
         }
       }
 
@@ -590,7 +602,19 @@ xreg::DICOMFIleBasicFields xreg::ReadDICOMFileBasicFields(const std::string& dcm
         {
           xregASSERT(dist_src_to_pat_attr.GetNumberOfValues() == 1);
           
-          dcm_info.dist_src_to_pat_mm = dist_src_to_pat_attr.GetValue();
+          const auto src_to_pat_mm = dist_src_to_pat_attr.GetValue();
+
+          // Some datasets have this value, but it is set to zero and is not useful.
+          // Only populate this field when the value is non-zero.
+          if (src_to_pat_mm > 1.0e-8)
+          {
+            dcm_info.dist_src_to_pat_mm = src_to_pat_mm;
+          }
+          else
+          {
+            std::cerr << "WARNING: source-to-patient distance field present, "
+              "but not a positive value. Discarding." << std::endl;
+          }
         }
       }
 

--- a/lib/file_formats/xregH5ProjDataIO.cpp
+++ b/lib/file_formats/xregH5ProjDataIO.cpp
@@ -31,12 +31,12 @@
 #include "xregHDF5Internal.h"
 #include "xregH5CamModelIO.h"
 
+const char* xreg::kXREG_PROJ_DATA_ATTR_STR = "proj-data";
+
 namespace
 {
 
 using namespace xreg;
-
-const char* kXREG_PROJ_DATA_ATTR_STR = "proj-data";
 
 void AddProjDataLandsHelper(const LandMap2& lands, H5::Group* h5,
                             const bool delete_existing = false)

--- a/lib/file_formats/xregH5ProjDataIO.h
+++ b/lib/file_formats/xregH5ProjDataIO.h
@@ -38,6 +38,8 @@ class Group;
 namespace xreg
 {
 
+extern const char* kXREG_PROJ_DATA_ATTR_STR;
+
 void CopyProjDataH5(const H5::Group& src_proj_h5, H5::Group* dst_proj_h5);
 
 void ReadProjDataFromH5AndWriteToDisk(const H5::Group& h5, const std::string& dst_disk_path);

--- a/lib/file_formats/xregRTKGeom.cpp
+++ b/lib/file_formats/xregRTKGeom.cpp
@@ -1,0 +1,98 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregRTKGeom.h"
+
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "xregAssert.h"
+#include "xregStringUtils.h"
+
+xreg::RTKGeomInfo xreg::ReadRTKGeomInfoFromXMLFile(const std::string& xml_path)
+{
+  using boost::property_tree::ptree;
+
+  RTKGeomInfo geom_info;
+
+  ptree pt;
+  read_xml(xml_path, pt);
+
+  auto& geom_children = pt.get_child("RTKThreeDCircularGeometry");
+
+  geom_info.src_to_iso_center_dist_mm = geom_children.get<CoordScalar>(
+                                                "SourceToIsocenterDistance");
+  
+  geom_info.src_to_det_dist_mm = geom_children.get<CoordScalar>(
+                                                "SourceToDetectorDistance");
+
+  for (auto it = geom_children.begin(); it != geom_children.end(); ++it)
+  {
+    if (it->first == "Projection")
+    {
+      RTKGeomInfo::ProjInfo tmp_proj_info;
+      
+      auto& proj_node = it->second;
+
+      tmp_proj_info.gantry_ang_deg = proj_node.get<CoordScalar>("GantryAngle");
+
+      try
+      {
+        tmp_proj_info.proj_off_x = proj_node.get<CoordScalar>("ProjectionOffsetX");
+      }
+      catch (const boost::property_tree::ptree_bad_path&)
+      {
+        tmp_proj_info.proj_off_x = 0;
+      }
+
+      try
+      {
+        tmp_proj_info.proj_off_y = proj_node.get<CoordScalar>("ProjectionOffsetY");
+      }
+      catch (const boost::property_tree::ptree_bad_path&)
+      {
+        tmp_proj_info.proj_off_y = 0;
+      }
+
+      const auto mat_vals = StringCast<CoordScalar>(
+                              StringSplit(proj_node.get<std::string>("Matrix"), " \t\n\r"));
+     
+      xregASSERT(mat_vals.size() == 12);
+
+      int i = 0;
+      for (int r = 0; r < 3; ++r)
+      {
+        for (int c = 0; c < 4; ++c, ++i)
+        {
+          tmp_proj_info.cam_mat(r,c) = mat_vals[i];
+        }
+      }
+
+      geom_info.proj_infos.push_back(tmp_proj_info);
+    }
+  }
+
+  return geom_info;
+}
+

--- a/lib/file_formats/xregRTKGeom.h
+++ b/lib/file_formats/xregRTKGeom.h
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef XREGRTKGEOM_H_
+#define XREGRTKGEOM_H_
+
+#include "xregCommon.h"
+
+namespace xreg
+{
+
+struct RTKGeomInfo
+{
+  CoordScalar src_to_iso_center_dist_mm;
+  
+  CoordScalar src_to_det_dist_mm;
+
+  struct ProjInfo
+  {
+    CoordScalar gantry_ang_deg;
+
+    CoordScalar proj_off_x;
+    CoordScalar proj_off_y;
+
+    Mat3x4 cam_mat;
+  };
+
+  std::vector<ProjInfo> proj_infos;
+};
+
+RTKGeomInfo ReadRTKGeomInfoFromXMLFile(const std::string& xml_path);
+
+}  // xreg
+
+#endif
+

--- a/lib/image/CMakeLists.txt
+++ b/lib/image/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020 Robert Grupp
+# Copyright (c) 2020-2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,5 +29,6 @@ add_library(xreg_image OBJECT ${XREG_CUR_LIB_HEADERS}
                               xregProjData.cpp
                               xregImageIntensLogTrans.cpp
                               xregImageAddPoissonNoise.cpp
-                              xregProjPreProc.cpp)
+                              xregProjPreProc.cpp
+                              xregLocalContrastNorm.cpp)
 

--- a/lib/image/xregLocalContrastNorm.cpp
+++ b/lib/image/xregLocalContrastNorm.cpp
@@ -1,0 +1,271 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregLocalContrastNorm.h"
+
+#include "xregAssert.h"
+#include "xregOpenCVUtils.h"
+#include "xregNormDist.h"
+
+namespace
+{
+
+// The first image returned has the filtered value subtracted from original intensity
+// The second image returned contains the sigma values (local sum of the squared values
+// in the first image returned)
+std::tuple<cv::Mat,cv::Mat> LocalContrastNormJarrettHelper(const cv::Mat& input_img,
+                                                           const int win_len_rows,
+                                                           const int win_len_cols)
+{
+  using namespace xreg;
+
+  xregASSERT((win_len_rows % 2) == 1);
+  xregASSERT((win_len_cols % 2) == 1);
+  xregASSERT(win_len_rows > 0);
+  xregASSERT(win_len_cols > 0);
+  
+  const int half_win_len_rows = win_len_rows / 2;
+  const int half_win_len_cols = win_len_cols / 2;
+
+  // TODO: add an assert on float input image
+  // TODO: put some asserts here verifying that input_img has sufficient dimensions
+
+  auto get_sigma = [] (const int len)
+  {
+    return ((((static_cast<float>(len) - 1.0f) * 0.5f) - 1.0f) * 0.3f) + 0.8f;
+  };
+ 
+  // compute the guassian weighting filter
+  NormalDist2DIndep norm_dist(0, 0, get_sigma(win_len_cols), get_sigma(win_len_rows));
+  
+  MatMxN wgts(win_len_rows, win_len_cols);
+
+  {  
+    float wgts_sum = 0;
+
+    for (int r = -half_win_len_rows; r <= half_win_len_rows; ++r)
+    {
+      const int wgts_r_idx = r + half_win_len_rows;
+
+      for (int c = -half_win_len_cols; c <= half_win_len_cols; ++c)
+      {
+        const float w = norm_dist(c, r);
+
+        wgts_sum += w;
+
+        wgts(wgts_r_idx, c + half_win_len_cols) = w;
+      }
+    }
+   
+    // filter should sum to one 
+    wgts /= wgts_sum;
+  }
+
+  // Setup the image that will hold values of subtracting the Gaussian
+  // filtered values from the input.
+  const int subtr_img_nr = input_img.rows - (win_len_rows - 1);
+  const int subtr_img_nc = input_img.cols - (win_len_cols - 1);
+
+  cv::Mat subtr_img = input_img(cv::Rect(
+                         half_win_len_cols, half_win_len_rows,
+                         subtr_img_nc, subtr_img_nr)).clone();
+
+  cv::Rect roi;
+  roi.height = win_len_rows;
+  roi.width  = win_len_cols;
+
+  for (int r = 0; r < subtr_img_nr; ++r)
+  {
+    auto* subtr_row = &subtr_img.at<float>(r,0);
+  
+    roi.y = r;
+
+    for (int c = 0; c < subtr_img_nc; ++c)
+    {
+      roi.x = c;
+
+      cv::Mat input_roi = input_img(roi);
+
+      float wgt_sum = 0;
+      for (int win_r = 0; win_r < win_len_rows; ++win_r)
+      {
+        for (int win_c = 0; win_c < win_len_cols; ++win_c)
+        {
+          wgt_sum += wgts(win_r,win_c) * input_roi.at<float>(win_r,win_c);
+        }
+      }
+
+      subtr_row[c] = subtr_row[c] - wgt_sum;
+    }
+  }
+
+  const int v_img_nr = subtr_img_nr - (win_len_rows - 1);
+  const int v_img_nc = subtr_img_nc - (win_len_cols - 1);
+
+  cv::Mat v_img = subtr_img(cv::Rect(
+                      half_win_len_cols, half_win_len_rows,
+                      v_img_nc, v_img_nr)).clone();
+
+  cv::Mat sigma_img(v_img_nr, v_img_nc, v_img.type());
+  
+  for (int r = 0; r < v_img_nr; ++r)
+  {
+    auto* v_img_row = &v_img.at<float>(r,0);
+    auto* sigma_row = &sigma_img.at<float>(r,0);
+  
+    roi.y = r;
+
+    for (int c = 0; c < v_img_nc; ++c)
+    {
+      roi.x = c;
+
+      cv::Mat v_roi = subtr_img(roi);
+
+      float wgt_sum = 0;
+      for (int win_r = 0; win_r < win_len_rows; ++win_r)
+      {
+        for (int win_c = 0; win_c < win_len_cols; ++win_c)
+        {
+          const auto v = v_roi.at<float>(win_r,win_c);
+
+          wgt_sum += wgts(win_r,win_c) * v * v;
+        }
+      }
+
+      v_img_row[c] = v_roi.at<float>(half_win_len_rows, half_win_len_cols);
+
+      sigma_row[c] = std::sqrt(wgt_sum);
+    }
+  }
+
+  return std::make_tuple(v_img, sigma_img);
+}
+
+}   // un-named
+
+cv::Mat xreg::LocalContrastNormStdNorm(const cv::Mat& input_img, const int win_len_rows,
+                                       const int win_len_cols,
+                                       const boost::optional<float>& border_val)
+{
+  xregASSERT(input_img.channels() == 1);
+
+  xregASSERT((win_len_rows % 2) == 1);
+  xregASSERT((win_len_cols % 2) == 1);
+  xregASSERT(win_len_rows > 0);
+  xregASSERT(win_len_cols > 0);
+  
+  const int win_half_len_cols = win_len_cols / 2;
+  const int win_half_len_rows = win_len_rows / 2;
+
+  const int out_nr = input_img.rows - (win_len_rows - 1);
+  const int out_nc = input_img.cols - (win_len_cols - 1);
+
+  const bool has_border = border_val.has_value();
+
+  cv::Mat out(has_border ? input_img.rows : out_nr,
+              has_border ? input_img.cols : out_nc,
+              CV_32FC1);
+ 
+  if (has_border)
+  {
+    out.setTo(*border_val);
+  }
+
+  const int row_off = has_border ? win_half_len_rows : 0;
+  const int col_off = has_border ? win_half_len_cols : 0;
+
+  cv::Rect input_roi;
+  input_roi.height = win_len_rows;
+  input_roi.width  = win_len_cols;
+
+  for (int r = 0; r < out_nr; ++r)
+  {
+    auto* row = &out.at<float>(r + row_off, 0);
+    
+    input_roi.y = r;
+
+    for (int c = 0; c < out_nc; ++c)
+    {
+      const int cc = c + col_off;
+
+      input_roi.x = c;
+
+      const auto mean_std_dev = MeanStdDev(input_img(input_roi));
+
+      row[cc] = static_cast<float>((row[cc] - std::get<0>(mean_std_dev)) /
+                                     std::max(1.0e-6, std::get<1>(mean_std_dev)));
+    }
+  }
+
+  return out;
+}
+
+cv::Mat xreg::LocalContrastNormJarrett(const cv::Mat& input_img,
+                                       const int win_len_rows,
+                                       const int win_len_cols,
+                                       const boost::optional<float>& border_val)
+{
+  constexpr float sigma_lower_bound = 1.0e-6f;
+  
+  cv::Mat v_img;
+  cv::Mat sigma_img;
+
+  std::tie(v_img, sigma_img) = LocalContrastNormJarrettHelper(
+                                  input_img, win_len_rows, win_len_cols);
+
+  const int v_img_nr = v_img.rows;
+  const int v_img_nc = v_img.cols;
+
+  for (int r = 0; r < v_img_nr; ++r)
+  {
+    auto* v_img_row = &v_img.at<float>(r,0);
+    
+    const auto* sigma_row = &sigma_img.at<float>(r,0);
+    
+    for (int c = 0; c < v_img_nc; ++c)
+    {
+      v_img_row[c] /= std::max(sigma_lower_bound, sigma_row[c]);
+    }
+  }
+  
+  cv::Mat out_img;
+
+  if (border_val)
+  {
+    out_img = cv::Mat(input_img.rows, input_img.cols, v_img.type());
+    
+    out_img.setTo(*border_val);
+   
+    v_img.copyTo(out_img(cv::Rect((input_img.cols - v_img.cols) / 2,
+                     (input_img.rows - v_img.rows) / 2,
+                     v_img.cols, v_img.rows)));
+  }
+  else
+  {
+    out_img = v_img;
+  }
+
+  return out_img;
+}
+

--- a/lib/image/xregLocalContrastNorm.h
+++ b/lib/image/xregLocalContrastNorm.h
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef XREGLOCALCONTRASTNORM_H_
+#define XREGLOCALCONTRASTNORM_H_
+
+#include <boost/optional.hpp>
+
+#include <opencv2/core/core.hpp>
+
+namespace xreg
+{
+
+// Implements local contrast normalization by replacing each pixel with the
+// value it would take when remapping a local window about it to have zero
+// mean and unit standard deviation. 
+cv::Mat LocalContrastNormStdNorm(const cv::Mat& input_img, const int win_len_rows,
+                                 const int win_len_cols,
+                                 const boost::optional<float>& border_val =
+                                   boost::optional<float>());
+
+// Implements local contrast normalization according to:
+// What is the Best Multi-Stage Architecture for Object Recognition?
+// Jarrett, et al.
+// Section 2: Model Architecture, Local Contrast Normalization Layer.
+cv::Mat LocalContrastNormJarrett(const cv::Mat& input_img, const int win_len_rows,
+                                 const int win_len_cols,
+                                 const boost::optional<float>& border_val =
+                                   boost::optional<float>());
+
+
+}  // xreg
+
+#endif
+

--- a/lib/opencv/xregOpenCVUtils.cpp
+++ b/lib/opencv/xregOpenCVUtils.cpp
@@ -1386,6 +1386,19 @@ void xreg::ComputeGradMag(cv::Mat& src_img, cv::Mat& grad_img, cv::Mat& tmp_img)
   cv::magnitude(grad_img, tmp_img, grad_img);
 }
 
+void xreg::SmoothAndGradMag(cv::Mat& src_img, cv::Mat& smooth_img, cv::Mat& grad_img,
+                            cv::Mat& tmp_img, const int smooth_kernel_width_pix)
+{
+  xregASSERT(smooth_kernel_width_pix > 0);
+  xregASSERT((smooth_kernel_width_pix % 2) == 1);
+
+  cv::GaussianBlur(src_img, smooth_img,
+                   cv::Size(smooth_kernel_width_pix, smooth_kernel_width_pix),
+                   0, 0);
+
+  ComputeGradMag(smooth_img, grad_img, tmp_img);
+}
+
 void xreg::ScaleTo8bppWithMax(const cv::Mat& src, cv::Mat* dst)
 {
   xregASSERT(src.type() == dst->type());

--- a/lib/opencv/xregOpenCVUtils.cpp
+++ b/lib/opencv/xregOpenCVUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Robert Grupp
+ * Copyright (c) 2020-2021 Robert Grupp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/opencv/xregOpenCVUtils.h
+++ b/lib/opencv/xregOpenCVUtils.h
@@ -102,6 +102,11 @@ void AbsImg(const cv::Mat& src, cv::Mat* dst);
 /// A temporary buffer image is required.
 void ComputeGradMag(cv::Mat& src_img, cv::Mat& grad_img, cv::Mat& tmp_img);
 
+/// \brief Smooths an image and then computes the gradient magnitude of the
+///        smoothed image.
+void SmoothAndGradMag(cv::Mat& src_img, cv::Mat& smooth_img, cv::Mat& grad_img,
+                      cv::Mat& tmp_img, const int smooth_kernel_width_pix = 3);
+
 /// \brief Scales an image to 8bpp (unsigned char) using ONLY the maximum
 ///        value of the input.
 ///

--- a/lib/opencv/xregOpenCVUtils.h
+++ b/lib/opencv/xregOpenCVUtils.h
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Robert Grupp
+ * Copyright (c) 2020-2021 Robert Grupp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/spatial/CMakeLists.txt
+++ b/lib/spatial/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020 Robert Grupp
+# Copyright (c) 2020-2021 Robert Grupp
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,5 +26,6 @@ add_library(xreg_spatial OBJECT ${XREG_CUR_LIB_HEADERS}
                                 xregSpatialPrimitives.cpp
                                 xregFitCircle.cpp
                                 xregFitPlane.cpp
+                                xregFitCylinder.cpp
                                 xregKDTree.cpp)
 

--- a/lib/spatial/xregFitCylinder.cpp
+++ b/lib/spatial/xregFitCylinder.cpp
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "xregFitCylinder.h"
+
+#include <Eigen/Dense>
+
+#include "xregAssert.h"
+#include "xregFitCircle.h"
+
+std::tuple<xreg::Pt3,xreg::CoordScalar> xreg::FitOrbitToPts(const Pt3List& pts)
+{
+  const size_type num_pts = pts.size();
+
+  xregASSERT(num_pts > 2);
+
+  // First, do PCA to get the approximate 3D plane of this orbit
+  Pt3 mean_pt = Pt3::Zero();
+
+  for (size_type i = 0; i < num_pts; ++i)
+  {
+    mean_pt += pts[i];
+  }
+
+  mean_pt /= static_cast<CoordScalar>(num_pts);
+
+  MatMxN pts_mat(3, num_pts);
+  
+  for (size_type i = 0; i < num_pts; ++i)
+  {
+    pts_mat.col(i) = pts[i] - mean_pt;
+  }
+
+  const MatMxN cov_mat = (pts_mat * pts_mat.transpose()) / static_cast<CoordScalar>(num_pts - 1);
+  
+  Eigen::SelfAdjointEigenSolver<MatMxN> eig_solver(cov_mat);
+  
+  const Pt3 u1 = eig_solver.eigenvectors().col(1);
+  const Pt3 u2 = eig_solver.eigenvectors().col(2);
+
+  // Next, project the 3D points onto the plane to get a collections of 2D points
+  // which lie on a circle
+
+  Pt2List pts_2d;
+  pts_2d.reserve(num_pts);
+ 
+  Eigen::Matrix<CoordScalar,2,3> u_proj;
+  u_proj.row(0) = u1.transpose();
+  u_proj.row(1) = u2.transpose();
+
+  for (size_type i = 0; i < num_pts; ++i)
+  {
+    pts_2d.push_back(u_proj * pts_mat.col(i));
+  }
+
+  // Next, fit a 2D circle to these points
+  Pt2 center_pt_2d;
+  CoordScalar radius = 0;
+  std::tie(center_pt_2d, radius) = FitCircle2D(pts_2d);
+
+  // Finally, recover the 3D location of the circle center
+  return std::make_tuple(mean_pt + (u1 * center_pt_2d(0)) + (u2 * center_pt_2d(1)), radius);
+}
+

--- a/lib/spatial/xregFitCylinder.h
+++ b/lib/spatial/xregFitCylinder.h
@@ -1,0 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Robert Grupp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef XREGFITCYLINDER_H_
+#define XREGFITCYLINDER_H_
+
+#include <tuple>
+
+#include "xregCommon.h"
+
+namespace xreg
+{
+
+// Fits a cylinder to a collection of points lying on a 3D circular orbit.
+// The first value returned is the estimated 3D center of rotation and the second
+// value returned is the estimated radius. 
+std::tuple<Pt3,CoordScalar> FitOrbitToPts(const Pt3List& pts);
+
+}  // xreg
+
+#endif
+

--- a/lib/transforms/xregPerspectiveXform.cpp
+++ b/lib/transforms/xregPerspectiveXform.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Robert Grupp
+ * Copyright (c) 2020-2021 Robert Grupp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -186,7 +186,7 @@ xreg::DecompProjMatQR(const Mat3x4& P)
 xreg::CoordScalar xreg::FocalLenFromIntrins(const Mat3x3& K, CoordScalar xps, CoordScalar yps)
 {
   // Average of the focal lengths
-  return std::abs((K(0,0) * xps) + (K(1,1) * ((yps < 0) ? xps : yps))) * 0.5;
+  return (std::abs((K(0,0) * xps)) + std::abs((K(1,1) * ((yps < 0) ? xps : yps)))) / CoordScalar(2);
 }
 
 xreg::Mat3x4 xreg::ProjMat3x4FromIntrinsExtrins(const Mat3x3& intrins, const Mat4x4& extrins)

--- a/lib/transforms/xregPerspectiveXform.cpp
+++ b/lib/transforms/xregPerspectiveXform.cpp
@@ -122,7 +122,7 @@ xreg::DecompProjMatQR(const Mat3x4& P)
   perm(2,0) = 1;
 
   const Mat3x3 A = P.block(0,0,3,3).transpose() * perm;
-  xregASSERT(A.determinant() > 1.0e-8);
+  xregASSERT(std::abs(A.determinant()) > 1.0e-8);
 
   Eigen::HouseholderQR<Mat3x3> qr(A);
 
@@ -134,30 +134,41 @@ xreg::DecompProjMatQR(const Mat3x4& P)
   CoordScalar rho = intrins(2,2);
 
   Mat3x3 rot_mat = perm * Q.transpose();
-
+  
+  Mat3x3 N = Mat3x3::Identity();
+  
   if (rot_mat.determinant() < 0)
   {
-    // rotation matrix is actually a reflection; flip the direction of one column, guess which
-    // column to flip based on negative signs in intrins.
-    
-    Mat3x3 N = Mat3x3::Identity();
+    // rotation matrix is actually a reflection; flip the direction of the last column
+    N(2,2) = -1;
+  }
 
+  if ((intrins(0,0) * intrins(1,1)) < 0)
+  {
+    // when the first two diagonal elements do not agree on sign
+    // flip one direction to get them both in agreement, but flip the direction
+    // needed to have the first two elements positive.
     if (intrins(0,0) < 0)
     {
       N(0,0) = -1;
     }
-    else if (intrins(1,1) < 0)
+    else
     {
       N(1,1) = -1;
     }
-    else
-    {
-      N(2,2) = -1;
-    }
-
-    intrins = intrins * N;
-    rot_mat = N * rot_mat;
+    
+    // also flip the third element to maintain handedness
+    N(2,2) = -1;
   }
+  else if (intrins(0,0) < 0)
+  {
+    // the first two elements agree on sign, but are negative, flip both
+    N(0,0) = -1;
+    N(1,1) = -1;
+  }
+  
+  intrins = intrins * N;
+  rot_mat = N * rot_mat;
 
   // set rotation in extrinsic
   Mat4x4 extrins = Mat4x4::Identity();
@@ -165,9 +176,9 @@ xreg::DecompProjMatQR(const Mat3x4& P)
  
   // recover translation
   extrins.block(0,3,3,1) = intrins.jacobiSvd(Eigen::ComputeThinU|Eigen::ComputeThinV).solve(P.block(0,3,3,1));
-
-  // make sure the bottom right element of intrinsics is 1
-  intrins /= rho;
+ 
+  // make sure the bottom right element of intrinsics has magnitude 1
+  intrins /= std::abs(rho);
 
   return std::make_tuple(intrins, extrins, rho);
 }


### PR DESCRIPTION
Major additions:
- Initial support for reading of projection data from the [SPARE dataset](https://image-x.sydney.edu.au/spare-challenge/),
- Using curl instead of wget in Linux/MacOS example build scripts. MacOS does not include wget, but does include curl,
- Improving DICOM metadata interpretation for radiographs,
- Adding some command line tools for manipulation of projection data files: concatenation and updating extrinsic parameters using transformations to a fiducial object,
- Adding tool for estimating orbital rotation axis from a collection of 2D projections of a fiducial object,
- Adding some local contrast normalization routines.

Other minor fixes/changes included.