### PR TITLE
Example build improvements

### DIFF
--- a/example_build_script
+++ b/example_build_script
@@ -264,6 +264,7 @@ cd $NLOPT_DIR
         -DWITH_CUDA:BOOL=OFF \
         -DWITH_CUFFT:BOOL=OFF \
         -DWITH_OPENCL:BOOL=OFF \
+        -DWITH_EIGEN:BOOL=OFF \
         -DBUILD_opencv_python2:BOOL=OFF \
         -DBUILD_opencv_python3:BOOL=OFF $OPENCV_GUI_FLAGS
 

--- a/example_build_script_2
+++ b/example_build_script_2
@@ -10,9 +10,12 @@
 # stop after the first failed command
 set -e
 
-NEED_TO_DOWNLOAD=true
-NEED_TO_BUILD_THIRD_PARTY=true
-NEED_TO_START_XREG=true
+# Disable these to skip downloading and building dependencies
+: ${NEED_TO_DOWNLOAD_THIRD_PARTY:=true}
+: ${NEED_TO_BUILD_THIRD_PARTY:=true}
+
+# Set this to false to not build xreg and only build the dependencies
+: ${NEED_TO_BUILD_XREG:=true}
 
 # This can be set to false when building on servers which do not have appropriate UI
 # dependencies. This can avoid linker errors.
@@ -81,7 +84,7 @@ fi
 # Operating system name
 OS_STR=`uname -s`
 
-if [ "$NEED_TO_DOWNLOAD" = true ]; then
+if [ "$NEED_TO_DOWNLOAD_THIRD_PARTY" = true ]; then
   echo "Downloading third party libraries..."
   
   # Choose the TBB package for your operating system:
@@ -333,6 +336,7 @@ if [ "$NEED_TO_BUILD_THIRD_PARTY" = true ] ; then
         -DWITH_CUDA:BOOL=OFF \
         -DWITH_CUFFT:BOOL=OFF \
         -DWITH_OPENCL:BOOL=OFF \
+        -DWITH_EIGEN:BOOL=OFF \
         -DBUILD_opencv_python2:BOOL=OFF \
         -DBUILD_opencv_python3:BOOL=OFF $OPENCV_GUI_FLAGS
 
@@ -345,7 +349,7 @@ fi
 
 # START: XREG BUILD:
 
-if [ "$NEED_TO_START_XREG" = true ]; then
+if [ "$NEED_TO_BUILD_XREG" = true ]; then
   
   mkdir $XREG_BUILD_DIR
   cd $XREG_BUILD_DIR

--- a/example_build_script_2
+++ b/example_build_script_2
@@ -14,7 +14,9 @@ NEED_TO_DOWNLOAD=true
 NEED_TO_BUILD_THIRD_PARTY=true
 NEED_TO_START_XREG=true
 
-DO_GUI=true
+# This can be set to false when building on servers which do not have appropriate UI
+# dependencies. This can avoid linker errors.
+: ${XREG_DO_GUI:=true}
 
 # Use these to explicitly set the build config
 #BUILD_CONFIG="Debug"
@@ -265,7 +267,7 @@ if [ "$NEED_TO_BUILD_THIRD_PARTY" = true ] ; then
   cd build
 
   VTK_NO_RENDER_FLAGS=""
-  if [ "$DO_GUI" = false ]; then
+  if [ "$XREG_DO_GUI" = false ]; then
     VTK_NO_RENDER_FLAGS="-DVTK_RENDERING_BACKEND=None -DVTK_Group_Rendering:BOOL=OFF"
   fi
 
@@ -310,7 +312,7 @@ if [ "$NEED_TO_BUILD_THIRD_PARTY" = true ] ; then
 
   # Need to set this OFF on MARCC (and other systems without the necessary deps)
   OPENCV_GUI_FLAGS=""
-  if [ "$DO_GUI" = false ]; then
+  if [ "$XREG_DO_GUI" = false ]; then
     OPENCV_GUI_FLAGS="-DBUILD_opencv_highgui:BOOL=OFF -DWITH_GSTREAMER:BOOL=OFF"
   fi
 

--- a/lib/opencv/xregOpenCVUtils.cpp
+++ b/lib/opencv/xregOpenCVUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020-2021 Robert Grupp
+ * Copyright (c) 2020-2022 Robert Grupp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +32,12 @@
 #include "xregITKIOUtils.h"
 #include "xregTBBUtils.h"
 #include "xregHDF5.h"
+
+#if CV_MAJOR_VERSION <= 3
+constexpr auto XREG_CV_GRAY2BGR = CV_GRAY2BGR;
+#else
+constexpr auto XREG_CV_GRAY2BGR = cv::COLOR_GRAY2BGR;
+#endif
 
 #define xregOCV_TO_ITK_IMAGE_REMAP_AND_WRITE_CASE(OCV_TYPE, SCALAR_TYPE) \
   case OCV_TYPE: \
@@ -78,7 +84,7 @@ cv::Mat xreg::OverlayEdges(const cv::Mat& base_img, const cv::Mat& edge_img,
     // TODO: error checking!
 
     dst_img = cv::Mat(nr, nc, CV_8UC3);
-    cv::cvtColor(base_img, dst_img, CV_GRAY2BGR);
+    cv::cvtColor(base_img, dst_img, XREG_CV_GRAY2BGR);
   }
 
   for (int r = 0; r < nr; ++r)
@@ -123,7 +129,7 @@ cv::Mat xreg::OverlayRectBoundary(const cv::Mat& base_img, const cv::Rect& rect,
     // TODO: error checking!
 
     dst_img = cv::Mat(nr, nc, CV_8UC3);
-    cv::cvtColor(base_img, dst_img, CV_GRAY2BGR);
+    cv::cvtColor(base_img, dst_img, XREG_CV_GRAY2BGR);
   }
 
   const unsigned char blue_val  = (edge_channel == 0) ? 255 : 0;
@@ -243,7 +249,7 @@ std::vector<cv::Mat> xreg::CreateSummaryTiledImages(const std::vector<cv::Mat>& 
         else  // Assuming everything else is grayscale!!!
         {
           cur_img = cv::Mat(cur_img_nr, cur_img_nc, CV_8UC3);
-          cv::cvtColor(src_imgs[src_img_idx], cur_img, CV_GRAY2BGR);
+          cv::cvtColor(src_imgs[src_img_idx], cur_img, XREG_CV_GRAY2BGR);
         }
 
         // it may be that the image is smaller than the tile
@@ -366,7 +372,7 @@ cv::Mat xreg::OverlayPtsAsCircles(const cv::Mat& img, const Pt2List& pts, const 
     // TODO: error checking!
 
     dst_img = cv::Mat(nr, nc, CV_8UC3);
-    cv::cvtColor(img, dst_img, CV_GRAY2BGR);
+    cv::cvtColor(img, dst_img, XREG_CV_GRAY2BGR);
   }
 
   const int num_pts = pts.size();
@@ -481,7 +487,7 @@ cv::Mat xreg::OverlayPts(const cv::Mat& img, const Pt2List& pts,
     // TODO: error checking!
 
     dst_img = cv::Mat(nr, nc, CV_8UC3);
-    cv::cvtColor(img, dst_img, CV_GRAY2BGR);
+    cv::cvtColor(img, dst_img, XREG_CV_GRAY2BGR);
   }
 
   const int num_pts = pts.size();

--- a/lib/regi/sim_metrics_2d/xregImgSimMetric2DBoundaryEdgesCPU.cpp
+++ b/lib/regi/sim_metrics_2d/xregImgSimMetric2DBoundaryEdgesCPU.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2020 Robert Grupp
+ * Copyright (c) 2020-2022 Robert Grupp
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,15 @@ void xreg::ImgSimMetric2DBoundaryEdgesCPU::allocate_resources()
   
   fixed_edge_dist_map_ = cv::Mat::zeros(fixed_img.size(), cv::DataType<Scalar>::type);
 
-  cv::distanceTransform(fixed_edges, fixed_edge_dist_map_, CV_DIST_L2, CV_DIST_MASK_PRECISE);
+#if CV_MAJOR_VERSION <= 3
+  constexpr auto XREG_CV_DIST_L2 = CV_DIST_L2;
+  constexpr auto XREG_CV_DIST_MASK_PRECISE = CV_DIST_MASK_PRECISE;
+#else
+  constexpr auto XREG_CV_DIST_L2 = cv::DIST_L2;
+  constexpr auto XREG_CV_DIST_MASK_PRECISE = cv::DIST_MASK_PRECISE;
+#endif
+
+  cv::distanceTransform(fixed_edges, fixed_edge_dist_map_, XREG_CV_DIST_L2, XREG_CV_DIST_MASK_PRECISE);
  
   // create storage for moving image edges 
   move_edge_imgs_ = AllocContiguousBufferForOpenCVImages<EdgePixelScalar>(img_num_rows_, img_num_cols_,


### PR DESCRIPTION
Fixes an issue with the example build scripts using Eigen when building the opencv dependency, which would cause a linker error on Ubuntu 20.04 with the system packages of Eigen and OpenCV installed (#21 ).

Adding some configuration options to the example build script 2.

Also fixing some compiler errors with opencv 4+.